### PR TITLE
Fix `screen_scale_ratio` for `MouseEvent` for MacOS

### DIFF
--- a/src/onsyuri/ONScripter.cpp
+++ b/src/onsyuri/ONScripter.cpp
@@ -80,9 +80,17 @@ void ONScripter::calcRenderRect() {
             screen_device_height = device_height;
         }
     }
-    
+
+#ifdef MACOSX
+    int width, height;
+    SDL_GetWindowSize(window, &width, &height);
+    screen_scale_ratio1 = (float)screen_width / width;
+    screen_scale_ratio2 = (float)screen_height / height;
+#else
     screen_scale_ratio1 = (float)screen_width / screen_device_width;
     screen_scale_ratio2 = (float)screen_height / screen_device_height;
+#endif
+
 
     // printf("## calcRenderRect screen %dx%d, screen_device %dx%d,  %.2f, %.2f\n", 
     //     screen_width, screen_height, 

--- a/src/onsyuri/ONScripter_event.cpp
+++ b/src/onsyuri/ONScripter_event.cpp
@@ -865,7 +865,7 @@ bool ONScripter::keyPressEvent( SDL_KeyboardEvent *event )
     }
     
     if ( event->type == SDL_KEYUP ){
-#if !defined(WINRT) && !defined(WEB) && (defined(WIN32) || defined(_WIN32) || defined(LINUX))
+#if !defined(WINRT) && !defined(WEB) && (defined(WIN32) || defined(_WIN32) || defined(LINUX) || defined(MACOSX))
       if ((event->keysym.mod & KMOD_ALT) && event->keysym.sym == SDLK_RETURN) {
         setFullScreen(!fullscreen_mode);
         return true;


### PR DESCRIPTION
Maybe it's also correct to calculate these ratios by `SDL_GetWindowSize` on other OS but I couldn't test it now.