### PR TITLE
Prevent stopping replaced chunk

### DIFF
--- a/src/onsyuri/ONScripter_event.cpp
+++ b/src/onsyuri/ONScripter_event.cpp
@@ -399,10 +399,12 @@ void midiCallback( int sig )
 
 extern "C" void waveCallback( int channel )
 {
-    SDL_Event event;
-    event.type = ONS_CHUNK_EVENT;
-    event.user.code = channel;
-    SDL_PushEvent(&event);
+    if (!Mix_Playing(channel)) {
+        SDL_Event event;
+        event.type = ONS_CHUNK_EVENT;
+        event.user.code = channel;
+        SDL_PushEvent(&event);
+    }
 }
 
 bool ONScripter::trapHandler()

--- a/src/onsyuri/ONScripter_sound.cpp
+++ b/src/onsyuri/ONScripter_sound.cpp
@@ -181,15 +181,15 @@ int ONScripter::playWave(Mix_Chunk *chunk, int format, bool loop_flag, int chann
     if (!chunk) return -1;
 
     Mix_Pause( channel );
-    if ( wave_sample[channel] ) Mix_FreeChunk( wave_sample[channel] );
-    wave_sample[channel] = chunk;
-
     if      (channel == 0)               Mix_Volume( channel, voice_volume * MIX_MAX_VOLUME / 100 );
     else if (channel == MIX_BGM_CHANNEL) Mix_Volume( channel, music_volume * MIX_MAX_VOLUME / 100 );
     else                                 Mix_Volume( channel, se_volume * MIX_MAX_VOLUME / 100 );
 
     if ( !(format & SOUND_PRELOAD) )
-        Mix_PlayChannel( channel, wave_sample[channel], loop_flag?-1:0 );
+        Mix_PlayChannel( channel, chunk, loop_flag?-1:0 );
+
+    if ( wave_sample[channel] ) Mix_FreeChunk( wave_sample[channel] );
+    wave_sample[channel] = chunk;
 
     return 0;
 }


### PR DESCRIPTION
A callback is registered to free trunk after it finished playing. However, when we replace a trunk, we will manually free the trunk and play a new trunk. However, freeing the old trunk will also call the callback, and the callback will then try to free the new trunk, which is unexpected.

We fixed it by playing the new trunk first and then manually free the trunk, so that the channel will be in playing mode and thus in the callback we can check if we still need to free the trunk by checking if the channel is in playing mode.