### PR TITLE
libretro: Fix a crash from audio

### DIFF
--- a/src/onsyuri_libretro/SDL_libretro.c
+++ b/src/onsyuri_libretro/SDL_libretro.c
@@ -188,8 +188,10 @@ SDL_libretro_ProduceAudio(retro_audio_sample_batch_t audio_batch_cb)
 {
     if (_audio == NULL)
         return;
+    SDL_LockAudioDevice(_audio->id);
     _audio->spec.callback(_audio, _audio->work_buffer, _audio->spec.size);
     audio_batch_cb((const int16_t*)_audio->work_buffer, _audio->spec.samples);
+    SDL_UnlockAudioDevice(_audio->id);
 }
 
 void


### PR DESCRIPTION
Hello I find the libretro core could crash when produce the audio, `SDL_LockAudioDevice` seems fix it.
Also I removed `apply_variables` in `retro_run`, since the only options can be changed durning runtime are  the mouse ones, which I think is not very useful, remove it so code is more clear, and all options changes are required a restart to take effects.

Thanks.