### PR TITLE
libretro: Enable ARM NEON and fix 'Texture too large' errors.

### DIFF
--- a/src/onsyuri/ONScripter.cpp
+++ b/src/onsyuri/ONScripter.cpp
@@ -273,6 +273,12 @@ void ONScripter::initSDL()
         texture_format = SDL_PIXELFORMAT_ABGR8888;
     max_texture_width = info.max_texture_width;
     max_texture_height = info.max_texture_height;
+    // pick a size limit for blt_texture when using the software renderer
+    if (max_texture_width == 0 || max_texture_height == 0) {
+        max_texture_width = 2048;
+        max_texture_height = 2048;
+    }
+
     SDL_RenderClear(renderer);
 
     underline_value = script_h.screen_height;

--- a/src/onsyuri/simd/int8x16.inl
+++ b/src/onsyuri/simd/int8x16.inl
@@ -112,7 +112,7 @@ namespace simd {
     _mm_store_ss(reinterpret_cast<float*>(m), _mm_castsi128_ps(a));
 #endif
 #elif USE_SIMD_ARM_NEON
-    vst1q_lane_u32(reinterpret_cast<uint32_t*>(m), a, 1);
+    vst1q_lane_u32(reinterpret_cast<uint32_t*>(m), vreinterpretq_u32_u8(a), 1);
 #endif
   }
 

--- a/src/onsyuri_libretro/CMakeLists.txt
+++ b/src/onsyuri_libretro/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 11)
 
+include(CheckSymbolExists)
+check_symbol_exists(__ARM_NEON "stdint.h" HAVE_NEON)
+
 set(SOURCES
   libretro.cpp
   ../onsyuri/AnimationInfo.cpp
@@ -301,6 +304,9 @@ target_include_directories(onsyuri_libretro PRIVATE
 target_compile_definitions(onsyuri_libretro PRIVATE
    -DUSE_BUILTIN_LAYER_EFFECTS -DENABLE_1BYTE_CHAR
 )
+if (HAVE_NEON)
+  target_compile_definitions(onsyuri_libretro PRIVATE USE_SIMD USE_SIMD_ARM_NEON)
+endif ()
 
 # Follow naming conventions for libretro cores
 set_target_properties(onsyuri_libretro PROPERTIES PREFIX "")

--- a/src/onsyuri_libretro/libretro.cpp
+++ b/src/onsyuri_libretro/libretro.cpp
@@ -183,6 +183,10 @@ retro_load_game(const struct retro_game_info* game)
     char* gamedir = dirname(SDL_strdup(game->path));
     chdir(gamedir);
 
+    // Ignore SDL_AUDIODRIVER and SDL_VIDEODRIVER.
+    SDL_SetHintWithPriority(SDL_HINT_AUDIODRIVER, "libretro", SDL_HINT_OVERRIDE);
+    SDL_SetHintWithPriority(SDL_HINT_VIDEODRIVER, "libretro", SDL_HINT_OVERRIDE);
+
     if (ons.openScript() != 0)
         return false;
 


### PR DESCRIPTION
Hello, here are some changes to enable ARM NEON for libretro and some small fixes.