### PR TITLE
Web: Add OPFS build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,19 @@
 cmake_minimum_required(VERSION 3.16.3)
 project(onsyuri)
 
+option(ONS_WEB_OPFS "Enable OPFS/Ofscreen framebuffer web runtime mode" OFF)
+set(ONSYURI_WEB_DEP_PREFIX "" CACHE PATH "Prefix containing include/ and lib/ for web dependencies")
+set(ONS_WEB_PORTBUILD_ROOT "" CACHE PATH "Legacy alias for ONSYURI_WEB_DEP_PREFIX")
+set(OPFS_MOUNT_PATH "/opfs" CACHE STRING "OPFS mount path for web (requires ONS_WEB_OPFS)")
+
+if(NOT ONSYURI_WEB_DEP_PREFIX)
+    if(ONS_WEB_PORTBUILD_ROOT)
+        set(ONSYURI_WEB_DEP_PREFIX "${ONS_WEB_PORTBUILD_ROOT}")
+    else()
+        set(ONSYURI_WEB_DEP_PREFIX "${PROJECT_SOURCE_DIR}/thirdparty/build/arch_wasm")
+    endif()
+endif()
+
 function(config_linux TARGET_NAME)
     add_executable(${TARGET_NAME} ${ONSYURI_CODE})
     install(TARGETS ${TARGET_NAME} RUNTIME)
@@ -373,12 +386,14 @@ endfunction()
 function(config_web TARGET_NAME)
     add_executable(${TARGET_NAME} ${ONSYURI_CODE})
     message("Web enviroment for "  ${TARGET_NAME})
-    target_link_directories(${TARGET_NAME} PRIVATE
-        ${PROJECT_SOURCE_DIR}/thirdparty/build/arch_wasm/lib
-    )
-    target_include_directories(${TARGET_NAME} PRIVATE
-        ${PROJECT_SOURCE_DIR}/thirdparty/build/arch_wasm/include
-    )
+    if(ONSYURI_WEB_DEP_PREFIX)
+        target_link_directories(${TARGET_NAME} PRIVATE
+            ${ONSYURI_WEB_DEP_PREFIX}/lib
+        )
+        target_include_directories(${TARGET_NAME} PRIVATE
+            ${ONSYURI_WEB_DEP_PREFIX}/include
+        )
+    endif()
 
     if(CMAKE_BUILD_TYPE MATCHES "MinSizeRel")
         target_compile_options(${TARGET_NAME} PRIVATE "-flto")
@@ -386,13 +401,29 @@ function(config_web TARGET_NAME)
     endif()
 
     # pass flags for emcc
-    set(EMCC_FLAGS "-o ${TARGET_NAME}.js -sASYNCIFY -sALLOW_MEMORY_GROWTH=1") # this two is very important! 
+    set(EMCC_FLAGS "${EMCC_FLAGS} -sALLOW_MEMORY_GROWTH=1")
     set(EMCC_FLAGS "${EMCC_FLAGS} -sMODULARIZE -sINVOKE_RUN=0 -sEXPORT_NAME=${TARGET_NAME}")
-    set(EMCC_FLAGS "${EMCC_FLAGS} -sEXPORTED_RUNTIME_METHODS=callMain,UTF8ToString,FS,PATH,IDBFS") # make as module
+    set(EMCC_FLAGS "${EMCC_FLAGS} -sEXPORTED_RUNTIME_METHODS=callMain,UTF8ToString,FS,PATH") # make as module
     set(EMCC_FLAGS "${EMCC_FLAGS} -sUSE_SDL=2 -sUSE_SDL_TTF=2 -sUSE_BZIP2=1")
     set(EMCC_FLAGS "${EMCC_FLAGS} -sUSE_SDL_IMAGE=2 -sSDL2_IMAGE_FORMATS=bmp,png,jpg")
     set(EMCC_FLAGS "${EMCC_FLAGS} -sUSE_SDL_MIXER=2 -sSDL2_MIXER_FORMATS=ogg,mp3,mid -sUSE_OGG=1 -sUSE_VORBIS=1 -sUSE_MPG123=1")
-    set(EMCC_FLAGS "${EMCC_FLAGS} -sFORCE_FILESYSTEM -lidbfs.js --use-preload-plugins")
+
+    if(CMAKE_BUILD_TYPE MATCHES "Debug")
+        set(EMCC_FLAGS "${EMCC_FLAGS} -sASSERTIONS=2")
+    endif()
+
+    if(ONS_WEB_OPFS)
+        target_compile_options(${TARGET_NAME} PRIVATE -pthread -matomics -mbulk-memory)
+        target_link_options(${TARGET_NAME} PRIVATE -pthread -matomics -mbulk-memory)
+        set(EMCC_FLAGS "${EMCC_FLAGS} -sPROXY_TO_PTHREAD=1") # pthread is required for OPFS
+        set(EMCC_FLAGS "${EMCC_FLAGS} -sWASM_WORKERS=1 -sAUDIO_WORKLET=1") # needed for audio
+        set(EMCC_FLAGS "${EMCC_FLAGS} -sOFFSCREEN_FRAMEBUFFER=1") # needed to renderer
+        set(EMCC_FLAGS "${EMCC_FLAGS} -sWASMFS=1 -sFORCE_FILESYSTEM=1 -lopfs.js")
+    else()
+        set(EMCC_FLAGS "-o ${TARGET_NAME}.js -sASYNCIFY") # required in non threaded mode
+        set(EMCC_FLAGS "${EMCC_FLAGS} -sFORCE_FILESYSTEM -lidbfs.js --use-preload-plugins")
+    endif()
+
     set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS ${EMCC_FLAGS})
     target_compile_options(${TARGET_NAME} PRIVATE 
         -Wno-invalid-source-encoding
@@ -403,6 +434,12 @@ function(config_web TARGET_NAME)
         LINUX
         USE_PARALLEL
     )
+    if(ONS_WEB_OPFS)
+        target_compile_definitions(${TARGET_NAME} PRIVATE
+            WEB_OPFS
+            OPFS_MOUNT_PATH="${OPFS_MOUNT_PATH}"
+        )
+    endif()
     target_link_libraries(${TARGET_NAME} PRIVATE
         lua
     )

--- a/src/onsyuri/BaseReader.h
+++ b/src/onsyuri/BaseReader.h
@@ -34,7 +34,7 @@ extern "C" int mkdir_ons(const char *path, mode_t mode);
 #define mkdir mkdir_ons
 #endif
 
-#if defined(WEB)
+#if defined(WEB) && !defined(WEB_OPFS)
 extern "C" FILE *fopen_ons(const char *str, const char *mode);
 #define fopen fopen_ons
 #endif

--- a/src/onsyuri/ONScripter.cpp
+++ b/src/onsyuri/ONScripter.cpp
@@ -292,8 +292,10 @@ void ONScripter::initSDL()
     EM_ASM(
         self.g_screen_width = $0;
         self.g_screen_height = $1;
-        let canvas = document.getElementById('canvas');
-        if(scale_full && canvas) scale_full(canvas, self.g_screen_width/self.g_screen_height);
+        if (typeof document !== 'undefined') {
+            let canvas = document.getElementById('canvas');
+            if (scale_full && canvas) scale_full(canvas, self.g_screen_width / self.g_screen_height);
+        }
     , screen_width, screen_height);
 #endif
     dirty_rect.setDimension(screen_width, screen_height);

--- a/src/onsyuri/ONScripter.h
+++ b/src/onsyuri/ONScripter.h
@@ -50,6 +50,19 @@
 #include <smpeg.h>
 #endif    
 
+#if defined(WEB_OPFS)
+#include <emscripten/html5_webgl.h>
+
+static inline void RenderPresentWebglCommit(SDL_Renderer *renderer)
+{
+    SDL_RenderPresent(renderer);
+    emscripten_webgl_commit_frame();
+}
+
+#undef SDL_RenderPresent
+#define SDL_RenderPresent RenderPresentWebglCommit
+#endif
+
 #define DEFAULT_VIDEO_SURFACE_FLAG (SDL_SWSURFACE)
 
 #define DEFAULT_BLIT_FLAG (0)

--- a/src/onsyuri/onscripter_main.cpp
+++ b/src/onsyuri/onscripter_main.cpp
@@ -260,7 +260,9 @@ extern "C" void playVideoIOS(const char *filename, bool click_flag, bool loop_fl
 #if defined(WEB)
 #include <emscripten.h>
 
+#if !defined(WEB_OPFS)
 #undef fopen
+#endif
 
 /*
 * fetch the file from server beforce fopen for lazyload
@@ -347,6 +349,23 @@ extern "C" void playVideoWeb(const char *path, bool click_flag, bool loop_flag)
     {
         SDL_Delay(5);
     }
+}
+#endif
+#if defined(WEB_OPFS)
+#ifndef OPFS_MOUNT_PATH
+#define OPFS_MOUNT_PATH "/opfs"
+#endif
+
+#include <emscripten/wasmfs.h>
+void init_opfs(void) {
+    backend_t wasmfs_backend = wasmfs_create_opfs_backend();
+
+    int err = wasmfs_create_directory(OPFS_MOUNT_PATH, 777, wasmfs_backend);
+    if (err && errno != EEXIST) {
+        utils::printError("OPFS initialization failed: %d (errno: %d)\n", err, errno);
+        return;
+    }
+    utils::printInfo("OPFS initialized at '" OPFS_MOUNT_PATH "'\n");
 }
 #endif
 
@@ -532,6 +551,10 @@ int main(int argc, char *argv[])
 #if defined(RENDER_FONT_OUTLINE)
     ons.renderFontOutline();
 #endif
+#endif
+
+#if defined(WEB_OPFS)
+    init_opfs();
 #endif
 
     // ----------------------------------------


### PR DESCRIPTION
Hey everyone, thanks a ton for porting onscripter to emscripten! 
I'm currently making a web-app to play VNs via PWA (mostly for IOS), and IDBFS just won't cut it there. 
It'd also be nice to have a web demo where users can directly drop game zips and play them in their browser.

This also requires properly set COOP/COEP headers because of `SharedArrayBuffer` compared to previous web builds.

## TODO
- [x] Mount OPFS share in `main()`
- [x] Wrap `SDL_RenderPresent` and get frames to render
- [ ] Build cleanly against @kichikuou's [SDL2 fork](https://github.com/kichikuou/SDL/tree/emscripten_webgl), necessary to avoid regressions with main thread forwarding when using OFFSCREEN_FRAMEBUFFER
- [ ] Understand/fix pointer event asserts
- [ ] Get audio to work in the threaded context
- [ ] Write a new html shell using a worker to extract ZIPs into OPFS
- [ ] Document the new build type and write a shell script for it

If the requirement on a patched SDL2 is too much this can remain a fork.