### PR TITLE
Fix mixed arc/sar archive loading

### DIFF
--- a/src/onsyuri/NsaReader.cpp
+++ b/src/onsyuri/NsaReader.cpp
@@ -31,7 +31,6 @@
 NsaReader::NsaReader( unsigned int nsa_offset, char *path, int archive_type, const unsigned char *key_table )
         :SarReader( path, key_table )
 {
-    sar_flag = true;
     this->nsa_offset = nsa_offset;
     this->archive_type = archive_type;
     num_of_nsa_archives = 0;
@@ -57,8 +56,6 @@ int NsaReader::open( const char *nsa_path )
     char archive_name[256], archive_name2[250];
 
     if ( !SarReader::open( "arc.sar" ) ) archive_found = true;
-    
-    sar_flag = false;
 
     if (archive_type & ARCHIVE_TYPE_NS2){
         for ( i=0 ; i<MAX_NS2_ARCHIVE ; i++ ){
@@ -104,7 +101,6 @@ int NsaReader::open( const char *nsa_path )
 
 int NsaReader::openForConvert( char *nsa_name, int archive_type, unsigned int nsa_offset )
 {
-    sar_flag = false;
     if ( ( archive_info.file_handle = ::fopen( nsa_name, "rb" ) ) == NULL ){
         utils::printError( "can't open file %s\n", nsa_name );
         return -1;
@@ -162,31 +158,27 @@ size_t NsaReader::getFileLengthSub( ArchiveInfo *ai, const char *file_name )
 
 size_t NsaReader::getFileLength( const char *file_name )
 {
-    if ( sar_flag ) return SarReader::getFileLength( file_name );
-
     size_t ret;
     int i;
-    
+
     if ( ( ret = DirectReader::getFileLength( file_name ) ) ) return ret;
-    
+
     for ( i=0 ; i<num_of_ns2_archives ; i++ ){
         if ( (ret = getFileLengthSub( &archive_info_ns2[i], file_name )) ) return ret;
     }
-    
+
     if ( ( ret = getFileLengthSub( &archive_info, file_name )) ) return ret;
 
     for ( i=0 ; i<num_of_nsa_archives ; i++ ){
         if ( (ret = getFileLengthSub( &archive_info2[i], file_name )) ) return ret;
     }
 
-    return 0;
+    return SarReader::getFileLength( file_name );
 }
 
 size_t NsaReader::getFile( const char *file_name, unsigned char *buffer, int *location )
 {
     size_t ret;
-
-    if ( sar_flag ) return SarReader::getFile( file_name, buffer, location );
 
     if ( ( ret = DirectReader::getFile( file_name, buffer, location ) ) ) return ret;
 
@@ -209,7 +201,9 @@ size_t NsaReader::getFile( const char *file_name, unsigned char *buffer, int *lo
         }
     }
 
-    return 0;
+    ret = SarReader::getFile( file_name, buffer, location );
+    if ( !ret && location ) *location = ARCHIVE_TYPE_NONE;
+    return ret;
 }
 
 NsaReader::FileInfo NsaReader::getFileByIndex( unsigned int index )

--- a/src/onsyuri/NsaReader.cpp
+++ b/src/onsyuri/NsaReader.cpp
@@ -56,7 +56,7 @@ int NsaReader::open( const char *nsa_path )
     // make archive_name2 smaller, to avoid -Wformat-overflow
     char archive_name[256], archive_name2[250];
 
-    if ( !SarReader::open( "arc.sar" ) ) return 0;
+    if ( !SarReader::open( "arc.sar" ) ) archive_found = true;
     
     sar_flag = false;
 

--- a/src/onsyuri/NsaReader.h
+++ b/src/onsyuri/NsaReader.h
@@ -47,7 +47,6 @@ public:
     size_t putFile( FILE *fp, int no, size_t offset, size_t length, size_t original_length, int compression_type, bool modified_flag, unsigned char *buffer );
     
 private:
-    bool sar_flag;
     int nsa_offset;
     int archive_type;
     int num_of_nsa_archives;


### PR DESCRIPTION
#68 is caused by NsaReader returning early after opening `arc.sar` and skipping the other archives.
Proper mixed archive support didn't really work because `sar_flag` is causing the engine to skip looking for files in the `.nsa` archives.
I propose that we drop `sar_flag` entirely and instead read from the `arc` archives first and perform a lookup in the sar archive if an asset wasn't found there.

I tested this on tsukhime and it fixed the asset loading issues entirely, in my (limited) testing this also didn't regress games relying purely on `.nsa` archives either, and missing  `sar` archives were also still gracefully handled.

<img width="752" height="620" alt="image" src="https://github.com/user-attachments/assets/552e47cd-6a7b-4a2d-a6e7-5ee4067be48e" />
